### PR TITLE
fix: make the merge station method modify the underlying map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+.idea
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
The current approach does not modify the original map once the new min, max, and count have been calculated.

Changing the map to use pointers allows modifying the underlying map when setting the new values.